### PR TITLE
Fix #22: Fix RPC replies, adding the string format of the any bottle sent through socket.io

### DIFF
--- a/yarp.js
+++ b/yarp.js
@@ -42,7 +42,8 @@ yarp.Bottle = function Bottle(_bottle) {
 
         return {
             obj_type: _bottle.getObjType(),
-            content: _bottle.toObject()
+            content: _bottle.toObject(),
+            contentStr: _bottle.toString()
         };
     }
 


### PR DESCRIPTION
Fixes #22 

- Any Yarp message read from a port is forwarded to the browser through socket.io interface
  (io.emit()) as an Bottle.toSend() object, which is composed of two fields: the "obj_type"
  and the "content".
- "obj_type" is a Bottle.toObject() object which does not include the VOCABs encoded in the
  message.
- We add, along with the "content" a "contentStr", the string format Bottle.toString() of
  the message.

This was the most conservative solution not impacting any processing done on the existing
"content" field, although we might lose some performance.