### PR TITLE
Fix SIGINT, SIGTERM callback functions and add SIGQUIT callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/*
 build/*
 npm-debug.log
 tests/*
+.DS_Store
+

--- a/yarp.js
+++ b/yarp.js
@@ -4,22 +4,25 @@ var _yarp = require('./build/Release/YarpJS');
 var yarp = new Object();
 
 
-// make sure to close stuff when Ctrl+C arrives
-process.on('SIGINT',function(){
-    process.exit();
+// make sure to close stuff when Ctrl+C or closing signal arrives, but don't
+// force the process to exit, let it do on its own.
+// A second occurrence of the signal will be processed by the default handlers
+// and force stop the process (except for SIGQUIT).
+process.once('SIGINT',function(){
+    process.emit('exit');
 });
-
-
-// make sure to close stuff when closing signal arrives
-process.on('SIGTERM',function(){
-    process.exit();
+process.once('SIGTERM',function(){
+    process.emit('exit');
+});
+process.once('SIGQUIT',function(){
+    process.emit('exit');
 });
 
 
 
 // just open the network once
 yarp.Network = new _yarp.Network();
-process.on('exit',function(){
+process.once('exit',function(){
     yarp.Network.fini();
 });
 
@@ -199,7 +202,7 @@ yarp.Port = function Port(_port_type) {
 
 
     // make sure the port closes on exit (moreover this keeps the port from being inadvertently destroyed by te garbage collector)
-    process.on('exit', function _closeOnExit() {
+    process.once('exit', function _closeOnExit() {
         console.log(port_name);
         _port.close();
     });


### PR DESCRIPTION
Implements #24 .

The intended behavior is the following:
- A first closure signal SIGxxxx triggers an `exit` event which triggers
  the `exit` listeners (closure of the ports, etc).
- If the process then exits on its own, those listeners are not triggered
  again by the generated `exit` event.
- An eventual second closure signal SIGxxxx is processed by the default
handler.

Implementation:
- Add a listener callback for the SIGQUIT which is a signal that
  parent processes can use to gracioulsy terminate child processes.
- When such signals are captured, just send an `exit` event instead
  of calling 'process.exit()' which forces the process to exit.
- Call only once the `exit` listeners such that they are not called
  again when the process exits on its own generating a new `exit`
  event.