### PR TITLE
Workaround: remove listener to 'exit' event closing the ports for avoiding blocking call to _port.close()

### DIFF
--- a/yarp.js
+++ b/yarp.js
@@ -202,10 +202,10 @@ yarp.Port = function Port(_port_type) {
 
 
     // make sure the port closes on exit (moreover this keeps the port from being inadvertently destroyed by te garbage collector)
-    process.once('exit', function _closeOnExit() {
-        console.log(port_name);
-        _port.close();
-    });
+    // process.once('exit', function _closeOnExit() {
+    //     console.log(port_name);
+    //     _port.close();
+    // });
 
     // remove the _stayAliveCallback so that the port can be collected by garbage collector
     _port.clear = function() {


### PR DESCRIPTION
Fixes https://github.com/ami-iit/yarp-openmct/issues/59 (workaround).