### PR TITLE
Bump version to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "YarpJS",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "Carlo Ciliberto <cciliber@gmail.com>",
   "description": "JS bindings for YARP",
   "dependencies": {


### PR DESCRIPTION
I realized that we never tagged a version working with https://github.com/ami-iit/yarp-openmct .